### PR TITLE
annotation 1.35.1: Drop sections that involve Organism.dplyr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,10 @@
 Package: annotation
 Title: Genomic Annotation Resources
-Version: 1.35.0
-Date: 2025-07-18
+Version: 1.35.1
+Date: 2026-04-06
+Encoding: UTF-8
 Authors@R: c(person(role="aut", "Marc", "RJ Carlson", email = "mrjc42@gmail.com"),
-            person(role="aut", "Herve", "Pages", email = "hpages@fredhutch.org"),
+            person(role="aut", "Hervé", "Pagès", email = "hpages.on.github@gmail.com"),
             person(role="aut", "Sonali", "Arora", email = "sarora@fredhutch.org"),
             person(role="aut", "Valerie", "Obenchain", email = "valerie.obenchain@roswellpark.org"),
             person(role="aut", "Martin", "Morgan", email = "martin.morgan@roswellpark.org"),
@@ -18,7 +19,6 @@ Depends: R (>= 3.3.0),
          GenomeInfoDb,
          VariantAnnotation,
          AnnotationHub,
-         Organism.dplyr,
          TxDb.Hsapiens.UCSC.hg19.knownGene,
          TxDb.Hsapiens.UCSC.hg38.knownGene,
          TxDb.Mmusculus.UCSC.mm10.ensGene,
@@ -29,8 +29,6 @@ Depends: R (>= 3.3.0),
          BSgenome,
          TxDb.Athaliana.BioMart.plantsmart22
 License: Artistic-2.0
-Encoding: UTF-8
-LazyData: true
 VignetteBuilder: knitr
 biocViews: AnnotationWorkflow, Workflow
 Workflow: true

--- a/vignettes/Annotation_Resources.Rmd
+++ b/vignettes/Annotation_Resources.Rmd
@@ -14,7 +14,7 @@ author:
   email: maintainer@bioconductor.org
 output:
   BiocStyle::html_document
-date: 24 April 2018
+date: 6 April 2026
 KeyWords: annotation, next-generation sequencing, R, Bioconductor
 vignette: >
   %\VignetteIndexEntry{Genomic Annotation Resources}
@@ -116,16 +116,6 @@ th {
       <td> Full genome sequence for Homo sapiens. </td>
     </tr>
     <tr>
-      <td> Organism.dplyr </td>
-      <td>
-        <a href = "http://bioconductor.org/packages/Organism.dplyr/">
-        <div> src_organism </div>
-        </a>
-      </td>
-      <td> Collection of multiple annotations for a common organism
-           and genome build. </td>
-    </tr>
-    <tr>
       <td> AnnotationHub </td>
       <td>
         <a href = "http://bioconductor.org/packages/AnnotationHub/">
@@ -163,7 +153,6 @@ them with `BiocManager::install()`:
 if (!"BiocManager" %in% rownames(installed.packages()))
      install.packages("BiocManager")
 BiocManager::install(c("AnnotationHub", "Homo.sapiens",
-           "Organism.dplyr",
            "TxDb.Hsapiens.UCSC.hg19.knownGene",
            "TxDb.Hsapiens.UCSC.hg38.knownGene",
            "BSgenome.Hsapiens.UCSC.hg19", "biomaRt",
@@ -570,116 +559,6 @@ they compare to what you saw in the TxDb.Hsapiens.UCSC.hg19.knownGene package?
 <p class="back_to_top">[ <a href="#top">Back to top</a> ]</p>
 
 
-# Organism.dplyr src_organism Objects
-
-So what happens if you have data from multiple different Annotation objects.
-For example, what if you had gene SYMBOLS (found in an OrgDb object) and you
-wanted to easily match those up with known gene transcript names from a UCSC
-based TxDb object? There is an ideal tool that can help with this kind of
-problem and it's called an src_organism object from the Organism.dplyr package.
-src_organism objects and their related methods are able to query each of OrgDb
-and TxDb resources for you and then merge the results back together in way that
-lets you pretend that you only have one source for all your annotations.
-
-```{r}
-library(Organism.dplyr)
-```
-
-src_organism objects can be created for organisms that have both an OrgDb and a
-TxDb.  To see organisms that can have src_organism objects made, use the
-function supportOrganisms():
-```{r}
-supported <- supportedOrganisms()
-print(supported, n=Inf)
-```
-
-Notice how there are multiple entries for a single organism (e.g. three for
-Homo sapiens).  There is only one OrgDb per organism, but different TxDbs can be
-used. To specify a certain version of a TxDb to use, we can use the
-src_organism() function to create an src_organism object.
-```{r}
-library(org.Hs.eg.db)
-library(TxDb.Hsapiens.UCSC.hg38.knownGene)
-```
-```{r eval=FALSE}
-src <- src_organism("TxDb.Hsapiens.UCSC.hg38.knownGene")
-```
-```{r echo=FALSE}
-src <- src_organism("TxDb.Hsapiens.UCSC.hg38.knownGene", dbpath=tempfile())
-```
-```{r}
-src
-```
-
-We can also create one using the src_ucsc() function.  This will create an
-src_organism object using the most recent TxDb version available:
-```{r eval=FALSE}
-src <- src_ucsc("Homo sapiens")
-```
-```{r}
-src
-```
-
-The five methods that worked for all of the other Db objects that we have
-discussed (keytypes(), columns(), keys(), select(), and mapIds()) all work for
-src_organism objects.  Here, we use keytypes() to show which keytypes can be
-passed to the keytype argument of select().
-```{r}
-keytypes(src)
-```
-
-Use columns() to show which keytypes can be passed to the keytype argument of
-select().
-```{r}
-columns(src)
-```
-
-And that's it. You can now use these objects in the same way that you use OrgDb
-or TxDb objects. It works the same as the base objects that it contains:
-```{r}
-select(src, keys="4488", columns=c("symbol", "tx_name"), keytype="entrez")
-```
-
-Organism.dplyr also supports numerous Genomic Extractor functions allowing users
-to filter based on information contained in the OrgDb and TxDb objects.  To see
-the filters supported by a src_organism() object, use supportedFIlters():
-```{r}
-head(supportedFilters(src))
-```
-
-The ranged based accessors such as those in GenomicFeatures will also work.
-There are also "_tbl" functions (e.g. transcripts_tbl()) that return tbl
-objects instead of GRanges objects.  Complex filter statements can be given as
-input.  Here we declare a GRangesFilter and use two different type-returning
-accessors to query transcripts that either start with "SNORD" and are within our
-given GRangesFilter, or have symbol with symbol "ADA":
-
-```{r}
-gr <- GRangesFilter(GenomicRanges::GRanges("chr1:44000000-55000000"))
-transcripts(src, filter=~(symbol %startsWith% "SNORD" & gr) | symbol == "ADA")
-
-transcripts_tbl(src, filter=~(symbol %startsWith% "SNORD" & gr) | symbol == "ADA")
-```
-
-## Organism.dplyr exercises
-
-Exercise 7: Use the src_organism object to look up the gene symbol, transcript
-start and chromosome using select(). Then do the same thing using transcripts.
-You might expect that this call to transcripts will look the same as it did for
-the TxDb object, but (temporarily) it will not.
-
-Exercise 8: Look at the results from call the columns method on the src_organism
-object and compare that to what happens when you call columns on the
-org.Hs.eg.db object and then look at a call to columns on the
-TxDb.Hsapiens.UCSC.hg19.knownGene object.
-
-Exercise 9: Use the src_organism object with the transcripts method to look up
-the entrez gene IDs for all gene symbols that contain the letter 'X'.
-
-
-<p class="back_to_top">[ <a href="#top">Back to top</a> ]</p>
-
-
 # BSgenome Objects
 
 Another important annotation resource type is a BSgenome package[10].  There
@@ -734,7 +613,7 @@ functions will already be available for you to explore.
 
 ## BSgenome exercises
 
-Exercise 10: Use what you have just learned to extract the sequence for the
+Exercise 7: Use what you have just learned to extract the sequence for the
 PTEN gene.
 
 <p class="back_to_top">[ <a href="#top">Back to top</a> ]</p>
@@ -831,11 +710,11 @@ head(columns(ensembl))
 
 ## biomaRt exercises
 
-Exercise 11: Pull down GO terms for entrez gene id "1" from human by
+Exercise 8: Pull down GO terms for entrez gene id "1" from human by
 using the ensembl "hsapiens_gene_ensembl" dataset.
 
 
-Exercise 12: Now compare the GO terms you just pulled down to the same
+Exercise 9: Now compare the GO terms you just pulled down to the same
 GO terms from the org.Hs.eg.db package (which you can now retrieve
 using select()). What differences do you notice? Why do you suspect
 that is?
@@ -1085,62 +964,6 @@ you are looking at.
 ## Exercise 7:
 
 ```{r eval=FALSE}
-keys <- keys(Homo.sapiens, keytype="TXID")
-res1 <- select(Homo.sapiens,
-               keys= keys,
-       	       columns=c("SYMBOL","TXSTART","TXCHROM"), keytype="TXID")
-
-head(res1)
-```
-
-And to do it using transcripts you do it like this:
-```{r}
-res2 <- transcripts(Homo.sapiens, columns="SYMBOL")
-head(res2)
-```
-
-
-## Exercise 8:
-
-```{r}
-columns(Homo.sapiens)
-columns(org.Hs.eg.db)
-columns(TxDb.Hsapiens.UCSC.hg19.knownGene)
-## You might also want to look at this:
-transcripts(Homo.sapiens, columns=c("SYMBOL","CHRLOC"))
-```
-The key difference is that the TXSTART refers to the start of a
-transcript and originates in the TxDb object from the
-TxDb.Hsapiens.UCSC.hg19.knownGene package, while the CHRLOC refers to
-the same thing but originates in the OrgDb object from the
-org.Hs.eg.db package.  The point of origin is significant because the
-TxDb object represents a transcriptome from UCSC and the OrgDb
-is primarily gene centric data that originates at NCBI.  The upshot is
-that CHRLOC will not have as many regions represented as TXSTART,
-since there has to be an official gene for there to even be a record.
-The CHRLOC data is also locked in for org.Hs.eg.db as data for hg19,
-whereas you can swap in a different TxDb object to match the
-genome you are using to make it hg18 etc.  For these reasons, we
-strongly recommend using TXSTART instead of CHRLOC.  Howeverm CHRLOC
-still remains in the org packages for historical reasons.
-
-
-## Exercise 9:
-
-To find the keys that match, make use of the pattern and column arguments.
-```{r}
-xk = head(keys(Homo.sapiens, keytype="ENTREZID", pattern="X", column="SYMBOL"))
-xk
-```
-select verifies the results
-```{r}
-select(Homo.sapiens, xk, "SYMBOL", "ENTREZID")
-```
-
-
-## Exercise 10:
-
-```{r eval=FALSE}
 ## Get the transcript ranges grouped by gene
 txby <- transcriptsBy(Homo.sapiens, by="gene")
 ## look up the entrez ID for the gene symbol 'PTEN'
@@ -1153,7 +976,7 @@ res
 ```
 
 
-## Exercise 11:
+## Exercise 8:
 
 ```{r}
 ensembl <- useEnsembl(biomart = "ensembl", dataset="hsapiens_gene_ensembl")
@@ -1164,7 +987,7 @@ getBM(attributes=c('go_id', 'entrezgene_id'),
 		  mart = ensembl)
 ```
 
-## Exercise 12:
+## Exercise 9:
 
 ```{r}
 ids <- c("1")


### PR DESCRIPTION
Organism.dplyr is deprecated in BioC 3.23 and will go away in BioC 3.24.